### PR TITLE
fix typo in getParentColumn function

### DIFF
--- a/src/Traits/ClosureTable.php
+++ b/src/Traits/ClosureTable.php
@@ -98,10 +98,10 @@ trait ClosureTable
      */
     protected function getParentColumn()
     {
-        if (! isset($this->parentColunm)) {
+        if (! isset($this->parentColumn)) {
             return 'parent';
         }
-        return $this->parentColunm;
+        return $this->parentColumn;
     }
     /**
      * Get ancestor column with table name


### PR DESCRIPTION
I set `'parent_id'` to `$parentColumn` but `getParentColumn` function returned `'parent'`.
Because there is typo in `getParentColumn` function.

I fixed this problem.

thanks!